### PR TITLE
Docker multi-arch build and push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Docker meta
+        id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: |
@@ -50,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platform: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le
+          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker multi-arch build and push
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Build Docker image (linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le)
+    runs-on: ubuntu-latest
+    env:
+      GHCR_IMAGE_TAG: ghcr.io/${{ github.repository_owner }}/smart-tv-telegram
+      DH_IMAGE_TAG: ${{ secrets.DOCKERHUB_USERNAME }}/smart-tv-telegram
+
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE_TAG }}
+            ${{ env.DH_IMAGE_TAG }}
+          tag-sha: true
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platform: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, linux/ppc64le
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.actor }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push


### PR DESCRIPTION
This PR resolves #13.
The created images are pushed to GitHub Container Registry (ghcr.io) and Docker Hub. Remember to set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in your repository secret settings. 